### PR TITLE
Recalbox version 4.1 download url changed.

### DIFF
--- a/package/recalboxOS/recalboxOS.mk
+++ b/package/recalboxOS/recalboxOS.mk
@@ -15,8 +15,8 @@ ifeq ($(BR2_PACKAGE_RECALBOXOS_UNSTABLE),y)
 else ifeq ($(BR2_PACKAGE_RECALBOXOS_NEXT),y)
 	RECALBOXOS_VERSION = 4.1-unstable
 	RECALBOXOS_EXTRA_DOWNLOADS = \
-		http://archive.recalbox.com/4.1/$(BR2_ARCH)/unstable/last/boot.tar.xz \
-		http://archive.recalbox.com/4.1/$(BR2_ARCH)/unstable/last/root.tar.xz
+		http://archive.recalbox.com/updates/v1.0/unstable/$(BR2_ARCH)/boot.tar.xz \
+		http://archive.recalbox.com/updates/v1.0/unstable/$(BR2_ARCH)/root.tar.xz
 else
 	RECALBOXOS_VERSION = $(RECALBOXOS_RELEASE)
 endif


### PR DESCRIPTION
Fix #16 : Impossible to download with recalbox 4.1

- Build tested on rpi1, rpi2 and  rpi3
- Hardware tested on rpi3